### PR TITLE
Merge  Alter Drop Primary Key Command #213 

### DIFF
--- a/src_smartcontract/sql_ddl_alter_modify/AlterModifyCommand.cpp
+++ b/src_smartcontract/sql_ddl_alter_modify/AlterModifyCommand.cpp
@@ -251,7 +251,12 @@ void AlterModifyCommand::validate(VirtualMachine* vm, AlterModifyCommandLog* log
 		if(!result){
 			throw new CdbException(L"Can not set the column unique because of table data.", __FILE__, __LINE__);
 		}
+	}
 
+	/**
+	 * When the type changed, need to check other indexes containing the column
+	 */
+	if(modifyContext->isTypeChanged()){
 		// FIXME check multiple index unique
 	}
 }

--- a/src_smartcontract_db/schema/ISchemaUptateListner.h
+++ b/src_smartcontract_db/schema/ISchemaUptateListner.h
@@ -13,6 +13,7 @@ namespace codablecash {
 class SchemaManager;
 class CdbTable;
 class ColumnModifyContext;
+class CdbTableIndex;
 
 class ISchemaUptateListner {
 public:
@@ -22,6 +23,7 @@ public:
 	virtual void schemaLoaded(SchemaManager* sc) = 0;
 	virtual void onCreateTable(SchemaManager* mgr, const CdbTable* table) = 0;
 	virtual void onAlterModify(SchemaManager* mgr, const CdbTable* table, const ColumnModifyContext* ctx) = 0;
+	virtual void onDropPrimaryKey(SchemaManager* mgr, const CdbTable* table, const CdbTableIndex* primaryKey) = 0;
 };
 
 } /* namespace codablecash */

--- a/src_smartcontract_db/schema/SchemaManager.h
+++ b/src_smartcontract_db/schema/SchemaManager.h
@@ -37,6 +37,7 @@ class AlterModifyCommandLog;
 class AlterRenameColumnCommandLog;
 class AlterRenameTableCommandLog;
 class ColumnModifyContext;
+class CdbTableIndex;
 
 class SchemaManager {
 public:
@@ -82,6 +83,7 @@ private:
 	void fireSchemaLoaded() noexcept;
 	void fireOnCreateTable(const CdbTable* table);
 	void fireOnAlterModify(const CdbTable* table, const ColumnModifyContext* ctx);
+	void fireOnDropPrimaryKey(const CdbTable* table, const CdbTableIndex* primaryKey);
 
 	CdbTable* findTableFromCommand(const AbstractAlterCommandLog* cmdlog);
 

--- a/src_smartcontract_db/table/CdbTable.cpp
+++ b/src_smartcontract_db/table/CdbTable.cpp
@@ -433,7 +433,7 @@ void CdbTable::removeIndex(const CdbTableIndex* ptr) noexcept {
 		}
 	}
 
-	if(removeIndex > 0){
+	if(removeIndex >= 0){
 		this->indexes->remove(removeIndex);
 	}
 }

--- a/src_smartcontract_db/table_store/CdbStorageManager.cpp
+++ b/src_smartcontract_db/table_store/CdbStorageManager.cpp
@@ -103,8 +103,16 @@ void CdbStorageManager::handleUniqueKeyOnAlterModify(TableStore* store,	const Co
 	}
 }
 
+void CdbStorageManager::onDropPrimaryKey(SchemaManager* mgr, const CdbTable* table, const CdbTableIndex* primaryKey) {
+	const CdbOid* tableOid = table->getOid();
+
+	TableStore* store = getTableStore(tableOid);
+	store->removeIndex(primaryKey);
+}
+
 TableStore* CdbStorageManager::getTableStore(const CdbOid* tableoid) noexcept {
 	return this->tableStoreMap->get(tableoid);
 }
+
 
 } /* namespace codablecash */

--- a/src_smartcontract_db/table_store/CdbStorageManager.h
+++ b/src_smartcontract_db/table_store/CdbStorageManager.h
@@ -40,6 +40,7 @@ public:
 
 private:
 	void handleUniqueKeyOnAlterModify(TableStore* store, const ColumnModifyContext* ctx);
+	virtual void onDropPrimaryKey(SchemaManager* mgr, const CdbTable* table, const CdbTableIndex* primaryKey);
 
 public:
 	static CdbKeyFactory keyFactory;

--- a/src_smartcontract_db/transaction/CdbTransactionManager.cpp
+++ b/src_smartcontract_db/transaction/CdbTransactionManager.cpp
@@ -78,6 +78,12 @@ void CdbTransactionManager::onAlterModify(SchemaManager* mgr,
 	// do nothing
 }
 
+void CdbTransactionManager::onDropPrimaryKey(SchemaManager* mgr,
+		const CdbTable* table, const CdbTableIndex* primaryKey) {
+	// do nothing
+}
+
+
 CdbTransaction* CdbTransactionManager::newTransaction(uint64_t transactionId) {
 	CdbTransaction* trx = new CdbTransaction(this, transactionId);
 

--- a/src_smartcontract_db/transaction/CdbTransactionManager.h
+++ b/src_smartcontract_db/transaction/CdbTransactionManager.h
@@ -38,6 +38,7 @@ public:
 	virtual void schemaLoaded(SchemaManager* sc);
 	virtual void onCreateTable(SchemaManager* mgr, const CdbTable* table);
 	virtual void onAlterModify(SchemaManager* mgr, const CdbTable* table, const ColumnModifyContext* ctx);
+	virtual void onDropPrimaryKey(SchemaManager* mgr, const CdbTable* table, const CdbTableIndex* primaryKey);
 
 	CdbTransaction* newTransaction(uint64_t transactionId);
 

--- a/src_test/smartcontract_db/table_alter_primary/test_exec_alter_primary.cpp
+++ b/src_test/smartcontract_db/table_alter_primary/test_exec_alter_primary.cpp
@@ -38,6 +38,10 @@ TEST_GROUP(TestExecAlterPrimaryGroup) {
 	}
 };
 
+
+/**
+ *
+ */
 TEST(TestExecAlterPrimaryGroup, dropPrimaryKey01){
 	TestDbSchemaAlter01 tester(this->env);
 	tester.init(1024*10);

--- a/src_test/smartcontract_db/table_alter_primary/test_exec_alter_primary.cpp
+++ b/src_test/smartcontract_db/table_alter_primary/test_exec_alter_primary.cpp
@@ -68,6 +68,23 @@ TEST(TestExecAlterPrimaryGroup, dropPrimaryKey01){
 		stmt->interpret(vm);
 	}
 
+	// again
+	{
+		SmartContractParser parser(sourceFile);
+		AlinousLang* lang = parser.getDebugAlinousLang();
+
+		AlterTableStatement* stmt = lang->alterTableStatement(); __STP(stmt);
+		CHECK(!parser.hasError())
+
+		AnalyzeContext* actx = new AnalyzeContext(); __STP(actx);
+		actx->setVm(vm);
+
+		stmt->preAnalyze(actx);
+		stmt->analyzeTypeRef(actx);
+		stmt->analyze(actx);
+
+		stmt->interpret(vm);
+	}
 }
 
 /**


### PR DESCRIPTION
After ALTER TABLE MODIFY command, implemented Alter Drop Primary Key Command.
Most of part is included in ALTER MODIFY.

Entire project map is here.
https://github.com/alinous-core/codablecash/projects/1
Fixes #213 
